### PR TITLE
Initial SRI support 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,13 @@
+export KOMOREBI_SETTINGS=$(CURDIR)/dev/dev.cfg
+
 develop: db.sqlite
 	poetry update
 
 run: develop
-	KOMOREBI_SETTINGS=$(CURDIR)/dev/dev.cfg poetry run flask --app komorebi --debug run
+	poetry run flask --app komorebi --debug run
+
+sri: develop
+	poetry run flask --app komorebi sri
 
 build:
 	find . -name \*.orig -delete

--- a/komorebi/app.py
+++ b/komorebi/app.py
@@ -3,7 +3,7 @@ import os
 from flask import Flask, render_template
 from werkzeug.middleware.proxy_fix import ProxyFix
 
-from komorebi import blog
+from komorebi import blog, sri
 
 
 def adjust_app_prefix(app, prefix="/"):
@@ -34,6 +34,7 @@ def create_app():
     app = Flask(__name__)
     app.config.from_envvar("KOMOREBI_SETTINGS")
     app.register_blueprint(blog.blog)
+    app.cli.add_command(sri.generate_hashes)
 
     @app.errorhandler(404)
     def page_not_found(_e):

--- a/komorebi/sri.json
+++ b/komorebi/sri.json
@@ -1,0 +1,5 @@
+{
+  "common.js": "sha384-RaHAuWfETJCGmfhA6Bn65/RJX/58hjVHNFY02bhOLNKcZrxkFrRVnp8V6nKe8mFy",
+  "luxon.min.js": "sha384-Z/CjPPwcFtY/yzyek5pMDDeLyIIgPlUht1Ycq6QFB+wgzeBAaPMMDjwS1r1YCED9",
+  "screen.css": "sha384-csohyUbadQoiTep1NZwHjjECWA5KdZzn5Wm4HttPcda6fFKdY16b63lvlbMGjSbq"
+}

--- a/komorebi/sri.py
+++ b/komorebi/sri.py
@@ -35,14 +35,15 @@ def generate_sri(
 
 @click.command("sri", help="Generate SRI cache")
 def generate_hashes():
-    static_root = os.path.join(os.path.dirname(__file__), "static")
+    app_root = os.path.dirname(__file__)
+    static_root = os.path.join(app_root, "static")
     hashes = {}
-    for root, dirs, files in os.walk(static_root):
+    for root, _, files in os.walk(static_root):
         for filename in files:
             if filename.endswith(SUFFIXES):
                 filepath = os.path.join(root, filename)
                 with open(filepath, "rb") as fh:
                     hashes[filepath[len(static_root) + 1 :]] = generate_sri(fh)
-    with open(os.path.join(os.path.dirname(__file__), "sri.json"), "w") as fh:
+    with open(os.path.join(app_root, "sri.json"), "w", encoding="UTF-8") as fh:
         json.dump(hashes, fh, indent=2, sort_keys=True)
         fh.write("\n")

--- a/komorebi/sri.py
+++ b/komorebi/sri.py
@@ -1,0 +1,23 @@
+import base64
+import hashlib
+import io
+
+
+def generate_sri(
+    fh: io.BufferedReader,
+    alg: str = "sha384",
+    block_size: int = 8192,
+) -> str:
+    """
+    A basic [subresource integrity](https://www.w3.org/TR/SRI/) hashing
+    implementation. This doesn't check the algorithm chosen nor does it support
+    multiple algorithms.
+    """
+    hashed = hashlib.new(alg)
+    while True:
+        blk = fh.read(block_size)
+        if not blk:
+            break
+        hashed.update(blk)
+    digest = base64.b64encode(hashed.digest()).decode("UTF-8")
+    return f"{alg}-{digest}"

--- a/tests/test_sri.py
+++ b/tests/test_sri.py
@@ -1,0 +1,19 @@
+from komorebi import sri
+
+import io
+import unittest
+
+
+class TestSRI(unittest.TestCase):
+    def test_binary(self):
+        self.assertEqual(
+            sri.generate_sri(io.BytesIO(b"abcedfg")),
+            "sha384-3Kqax0ynJR7oxUL8wK8YhBgFkA4p8nENqXfWfgUfUG79JT5ad1YKCXH31y4zTCXH",
+        )
+
+    def test_text(self):
+        """
+        File should be opened as binary.
+        """
+        with self.assertRaises(TypeError):
+            sri.generate_sri(io.StringIO("abcedfg"))


### PR DESCRIPTION
This does the first half of the work needed for #23. It doesn't add support for loading the file or function registration to Jinja.