### PR TITLE
Fix a type caught by PyLance but not MyPy

### DIFF
--- a/komorebi/feed.py
+++ b/komorebi/feed.py
@@ -24,7 +24,7 @@ def generate_feed(
     title: str,
     author: str,
     feed_id: str,
-    entries: t.Sequence[Entry],
+    entries: t.Iterable[Entry],
     subtitle: t.Optional[str] = None,
     rights: t.Optional[str] = None,
     modified: t.Optional[datetime] = None,


### PR DESCRIPTION
Fix a type caught by PyLance but not MyPy

<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request addresses a type annotation issue in the 'generate_feed' function, ensuring compatibility with PyLance by changing the type of the 'entries' parameter from 't.Sequence[Entry]' to 't.Iterable[Entry]'.

- **Bug Fixes**:
    - Corrected the type annotation for the 'entries' parameter in the 'generate_feed' function from 't.Sequence[Entry]' to 't.Iterable[Entry]' to fix a type issue caught by PyLance.

<!-- Generated by sourcery-ai[bot]: end summary -->