### PR TITLE
Version based on the release tag

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,11 +37,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: eifinger/setup-rye@v4.2.0
-        id: setup-rye
-        with:
-          version: "0.36.0"
-          enable-cache: true
-          cache-prefix: "rye-${{ matrix.python-version }}-test"
       - name: Install Python ${{ matrix.python-version }}
         run: rye pin ${{ matrix.python-version }}
       - name: Run tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 #:schema https://json.schemastore.org/pyproject.json
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
@@ -112,7 +112,10 @@ branch = true
 omit = ["src/komorebi/adjunct/*"]
 
 [tool.hatch.version]
-path = "src/komorebi/__init__.py"
+source = "vcs"
+
+[tool.hatch.build.hooks.vcs]
+version-file = "src/komorebi/_version.py"
 
 [tool.mypy]
 ignore_missing_imports = true

--- a/src/komorebi/__init__.py
+++ b/src/komorebi/__init__.py
@@ -4,5 +4,3 @@ __all__ = [
     "create_app",
     "create_wsgi_app",
 ]
-
-__version__ = "0.3.11"


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request removes the hardcoded version number from the __init__.py file, likely in preparation for a versioning system based on release tags.

- **Enhancements**:
    - Removed hardcoded version number from the __init__.py file.

<!-- Generated by sourcery-ai[bot]: end summary -->