### PR TITLE
Correct MIME type in self link tag in feed: should be Atom's

### DIFF
--- a/src/komorebi/feed.py
+++ b/src/komorebi/feed.py
@@ -47,7 +47,7 @@ def generate_feed(
         )
         xml.link(
             rel="self",
-            type="text/html",
+            type="application/atom+xml",
             hreflang="en",
             href=url_for(".feed", _external=True),
         )


### PR DESCRIPTION
<!-- Generated by sourcery-ai[bot]: start summary -->

## Summary by Sourcery

This pull request fixes the MIME type in the self link tag of the feed to ensure it adheres to Atom feed standards.

- **Bug Fixes**:
    - Corrected the MIME type in the self link tag of the feed from 'text/html' to 'application/atom+xml' to comply with Atom feed standards.

<!-- Generated by sourcery-ai[bot]: end summary -->