### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,7 @@
 ---
 name: Tests
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/kgaughan/komorebi/security/code-scanning/3](https://github.com/kgaughan/komorebi/security/code-scanning/3)

To fix the detected issue, add a `permissions` block that explicitly limits token privileges following the principle of least privilege. Since both jobs only check out the repository and run local linters/tests, setting `contents: read` is sufficient. This block can be added at the root of the workflow file (recommended), so all jobs inherit the same restrictions, and updates are simple. Insert the following section after the `name:` field and before the `on:` field:

```yaml
permissions:
  contents: read
```

No changes to existing steps, imports, or job logic are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Enhancements:
- Restrict workflow token privileges to read-only repository contents by adding a permissions block to the tests workflow