### PR TITLE
justfile

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -20,16 +20,18 @@ The output cache functionality will be replaced with Redis.
 Prep
 ====
 
-Run::
+Install just__ as a task runner. Run::
 
-    uv sync
+    just devel
+
+.. __: https://github.com/casey/just
 
 Development server
 ==================
 
 Run::
 
-    uv run flask --app komorebi --debug run
+    just dev-server
 
 The username and password specified in ``dev/dev.htpasswd`` are *username* and
 *password* respectively.
@@ -50,7 +52,7 @@ Regenerating subresource integrity hashes
 
 Run::
 
-    uv run flask --app komorebi sri
+    just sri
 
 SRI is less trouble than dealing with CSP. I should add something to generate a
 manifest of this stuff to avoid manual updates.

--- a/justfile
+++ b/justfile
@@ -1,0 +1,16 @@
+app := "komorebi"
+
+default:
+	@just --list
+
+# setup virtual environment
+devel:
+	@uv sync --frozen
+
+# run dev server
+dev-server:
+	@uv run flask --app {{app}} --debug run
+
+# regenerate SRI hashes
+sri:
+	@uv run flask --app {{app}} sri

--- a/justfile
+++ b/justfile
@@ -14,3 +14,7 @@ dev-server:
 # regenerate SRI hashes
 sri:
 	@uv run flask --app {{app}} sri
+
+# run the test suite
+tests:
+	@uv run pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,9 +139,11 @@ ban-relative-imports = "all"
 
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "-ra -q --cov=komorebi --junitxml=results.xml --cov-report html"
+addopts = "-ra --doctest-modules --cov=komorebi --junitxml=results.xml --cov-report html"
 junit_logging = "out-err"
 junit_family = "xunit2"
+pythonpath = ["src"]
+testpaths = ["tests"]
 
 [tool.coverage.run]
 branch = true


### PR DESCRIPTION
Also, run any doctests, just in case.

## Summary by Sourcery

Enhance the test configuration to include doctests and explicit discovery paths, and add a justfile for common development tasks.

Enhancements:
- Include doctests in pytest runs by adding --doctest-modules to addopts
- Configure pytest to use src as pythonpath and tests as testpaths
- Introduce a justfile with targets for listing commands, setting up the environment, starting the dev server, and regenerating SRI hashes