### PR TITLE
 Minimal dockerfile configuration with uv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,40 @@
-FROM python:3 AS build-env
+FROM ghcr.io/astral-sh/uv:bookworm-slim AS builder
+ENV UV_COMPILE_BYTECODE=1 UV_LINK_MODE=copy
 
-# We're going to be installing everything into a directory, so this isn't needed.
-ENV PIP_ROOT_USER_ACTION=ignore
+# Configure the Python directory so it is consistent
+ENV UV_PYTHON_INSTALL_DIR=/python
 
-# Using a context isn't enough: we need to mount the current directory within the build image.
-RUN --mount=type=bind,target=/tmp/komorebi,rw <<END
-# The Rye lockfile installs the app in editable mode, so we need to get rid of it.
-sed -i '/^-e /d' /tmp/komorebi/requirements.lock
+# Only use the managed Python version
+ENV UV_PYTHON_PREFERENCE=only-managed
 
-mkdir -p /opt/komorebi
-pip3 install --target=/opt/komorebi --prefix= -r /tmp/komorebi/requirements.lock
-pip3 install --target=/opt/komorebi --prefix= --no-deps /tmp/komorebi
-END
+# Install Python before the project for caching
+RUN uv python install 3.12
 
-FROM gcr.io/distroless/python3:latest
-COPY --from=build-env /opt/komorebi /opt/komorebi
+# Install the dependencies.
+WORKDIR /app
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=uv.lock,target=uv.lock \
+    --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
+    uv sync --locked --no-install-project --no-dev
 
-# This way, the application and its dependencies are importable.
-ENV PYTHONPATH=/opt/komorebi
-ENV KOMOREBI_SETTINGS=/path/to/app/komorebi.cfg
-EXPOSE 8000
+# Note: you must have built the wheel first, and there can only be one.
+# We have to do it this way because we've hatch configured to lean on the VCS
+# for versioning, `uv sync --locked --no-dev` won't work for us here.
+RUN --mount=type=cache,target=/root/.cache/uv \
+    --mount=type=bind,source=dist,target=dist \
+    uv pip install --no-deps dist/*.whl
+
+FROM gcr.io/distroless/cc:nonroot
+
+# Copy the Python version
+COPY --from=builder --chown=python:python /python /python
+
+WORKDIR /app
+# Copy the application from the builder
+COPY --from=builder --chown=app:app /app/.venv /app/.venv
+
+# Place executables in the environment at the front of the path
+ENV PATH="/app/.venv/bin:$PATH"
+
+ENTRYPOINT ["/app/.venv/bin/python3"]
 CMD ["-m", "komorebi", "--host", "0.0.0.0", "--port", "8000"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3 AS build-env
+
+# We're going to be installing everything into a directory, so this isn't needed.
+ENV PIP_ROOT_USER_ACTION=ignore
+
+# Using a context isn't enough: we need to mount the current directory within the build image.
+RUN --mount=type=bind,target=/tmp/komorebi,rw <<END
+# The Rye lockfile installs the app in editable mode, so we need to get rid of it.
+sed -i '/^-e /d' /tmp/komorebi/requirements.lock
+
+mkdir -p /opt/komorebi
+pip3 install --target=/opt/komorebi --prefix= -r /tmp/komorebi/requirements.lock
+pip3 install --target=/opt/komorebi --prefix= --no-deps /tmp/komorebi
+END
+
+FROM gcr.io/distroless/python3:latest
+COPY --from=build-env /opt/komorebi /opt/komorebi
+
+# This way, the application and its dependencies are importable.
+ENV PYTHONPATH=/opt/komorebi
+ENV KOMOREBI_SETTINGS=/path/to/app/komorebi.cfg
+EXPOSE 8000
+CMD ["-m", "komorebi", "--host", "0.0.0.0", "--port", "8000"]

--- a/justfile
+++ b/justfile
@@ -1,4 +1,5 @@
 app := "komorebi"
+docker_repo := "ghcr.io/kgaughan/" + app
 
 [private]
 default:
@@ -23,3 +24,10 @@ sri:
 # run the test suite
 tests:
 	@uv run --frozen pytest
+
+# build the docker image
+docker:
+	@rm -rf dist
+	@uv build --wheel
+	@docker buildx build -t {{docker_repo}}:$(git describe --tags --always) .
+	@docker tag {{docker_repo}}:$(git describe --tags --always) {{docker_repo}}:latest


### PR DESCRIPTION
This hews closely to the method given in:

 * https://www.joshkasuboski.com/posts/distroless-python-uv/
 * https://github.com/astral-sh/uv-docker-example
 * https://docs.astral.sh/uv/guides/integration/docker/

## Summary by Sourcery

Add a minimal multi-stage Dockerfile using uv for building a distroless Python image and integrate a "docker" target in justfile to automate wheel and Docker image builds with version tagging.

New Features:
- Provide a Dockerfile that installs Python and dependencies via uv and produces a non-root distroless image for the komorebi app
- Add a "docker" recipe to justfile to build the wheel, create Docker image with version and latest tags, and clean up previous builds