### PR TITLE
Sync with adjunct; obey mypy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,7 +126,7 @@ ignore = [
   "UP035",   # Deprecated import
   "EM101",   # Exceptions must not use strings
   "EM102",   # Exception must not use f-string literal
-  "TRY003",  # Avoid specifying long messages outside the exception class"
+  "TRY003",  # Avoid specifying long messages outside the exception class
 ]
 
 [tool.ruff.lint.isort]

--- a/src/komorebi/adjunct/compat.py
+++ b/src/komorebi/adjunct/compat.py
@@ -2,13 +2,15 @@ import typing as t
 
 
 def parse_header(line: str) -> tuple[str, dict[str, str]]:
-    """
-    Parse a Content-type like header.
+    """Parse HTTP headers with the same format as `Content-Type`.
 
-    Return the main content-type and a dictionary of options.
+    Args:
+        line: a HTTP header line
 
-    Copied, with _parseparam, from Python's cgi module until I can find a
-    better alternative.
+    Returns:
+        The main value and a dictionary of options.
+
+    (Copied from Python's `cgi` module until I can find a better alternative.)
     """
     parts = _parseparam(f";{line}")
     key = parts.__next__()

--- a/src/komorebi/adjunct/discovery.py
+++ b/src/komorebi/adjunct/discovery.py
@@ -1,5 +1,7 @@
-"""
-Discovery via HTML <link> elements.
+"""Discovery via HTML <link> elements.
+
+For most purposes, [adjunct.discovery.fetch_meta][] should do anything you
+need.
 """
 
 import contextlib
@@ -19,13 +21,24 @@ logger = logging.getLogger(__name__)
 # pylint: disable-msg=R0904
 class Extractor(HTMLParser):
     """
-    A simple subclass of `HTMLParser` for extracting metadata like from <meta>
-    and <link> tags from the header of a HTML document.
+    A simple subclass of [html.parser.HTMLParser][] for extracting metadata
+    like from `<meta>` and `<link>` tags from the header of a HTML document.
+
+    It's recommended you use the [adjunct.discovery.Extractor.extract][] class
+    method rather than instantiating this class directly.
+
+    Args:
+        base: the base URL for the document
+
+    Attributes:
+        base: the base URL for the document; the `<base>` tag is used if found
+        collected: any collected links; each entry is a dictionary of the attributes
+        properties: any collected `<meta>` tags with `property` and `content` attributes
     """
 
     def __init__(self, base: str) -> None:
         super().__init__()
-        self.base = base
+        self.base: str = base
         self.collected: list[dict[str, str]] = []
         self.properties: list[tuple[str, str]] = []
 
@@ -33,42 +46,44 @@ class Extractor(HTMLParser):
         tag = tag.lower()
         fixed_attrs = fix_attributes(attrs)
         if tag == "link":
-            self.append(fixed_attrs)
+            self._append(fixed_attrs)
         elif tag == "base" and "href" in fixed_attrs:
             self.base = parse.urljoin(self.base, fixed_attrs["href"])
         elif tag == "meta" and "property" in fixed_attrs and "content" in fixed_attrs:
             self.properties.append((fixed_attrs["property"], fixed_attrs["content"]))
 
-    def append(self, attrs: dict[str, str]) -> None:
-        """
-        Append the given set of attributes onto our list.
+    def _append(self, attrs: dict[str, str]) -> None:
+        """Append the given set of attributes onto our list.
 
         By separating this out, we can modify the behaviour in subclasses.
         """
         self.collected.append(attrs)
 
-    def fix_href(self, href: str) -> str:
-        """
-        Make the given href absolute to any previously discovered <base> tag.
-        """
+    def _fix_href(self, href: str) -> str:
+        """Make the given href absolute to any previously discovered <base> tag."""
         return parse.urljoin(self.base, href)
 
     @classmethod
     def extract(cls, fh: io.IOBase, base: str = ".", encoding: str = "UTF-8") -> "Extractor":
-        """
-        Extract the link tags from header of a HTML document to be read from
-        the file object, `fh`. The return value is a list of dicts where the
-        values of each are the attributes of the link elements encountered.
+        """Extract the link tags from header of a HTML document to be read.
+
+        Args:
+            fh: a file-like object to read the HTML document from.
+            base: A base path/URL to use of URLs in the document. Note that the `<base>` tag will take priority.
+            encoding: default text encoding to assume for the document.
+
+        Returns:
+            The parser with all links extracted and canonicalised.
         """
         parser = cls(base)
         with contextlib.closing(parser):
-            for chunk in safe_slurp(fh, encoding=encoding):
+            for chunk in _safe_slurp(fh, encoding=encoding):
                 parser.feed(chunk)
 
         # Canonicalise the URL paths.
         for link in parser.collected:
             if "href" in link:
-                link["href"] = parser.fix_href(link["href"])
+                link["href"] = parser._fix_href(link["href"])
 
         return parser
 
@@ -78,13 +93,25 @@ class Extractor(HTMLParser):
         logger.error("Error in Extractor: %s", message)  # pragma: no cover
 
 
-def safe_slurp(fh: io.IOBase, chunk_size: int = 65536, encoding: str = "UTF-8") -> t.Iterator[str]:
-    """
-    Safely convert file object, converting it to the given file encoding.
+def _safe_slurp(fh: io.IOBase, chunk_size: int = 65536, encoding: str = "UTF-8") -> t.Iterator[str]:
+    """Safely convert file object, converting it to the given file encoding.
 
     This handles situations such as UTF-8 characters on chunk boundaries
     gracefully.
+
+    Args:
+        fh: a file-like object to read the data from.
+        chunk_size: what should the approximate maximum size of each chunk be
+        encoding: text encoding to assume for the input data.
+
+    Yields:
+        Chunks of string data read from the file-like object.
     """
+    # Enforce a lower end: 6 will give us 31 bits of codepoint space coverage,
+    # though RFC3629 mandates a max of 4 for compatibility with UTF-16. The
+    # extra leeway shouldn't be a bad thing though. I'm hoping this is fine for
+    # other long encodings too.
+    chunk_size = max(chunk_size, 6)
     prelude = None
     while True:
         chunk = fh.read(chunk_size)
@@ -105,8 +132,18 @@ def safe_slurp(fh: io.IOBase, chunk_size: int = 65536, encoding: str = "UTF-8") 
 
 
 def fix_attributes(attrs: list[tuple[str, str | None]]) -> dict[str, str]:
-    """
-    Normalise and clean up the attributes, and put them in a dict.
+    """Normalise and clean up the attributes, and put them in a dict.
+
+    Attribute names are normalised to lowercase; whitespace within values is
+    trimmed; if the value of an attribute is `None`, it's replaced with an
+    empty string; and the values of the `rel` and `type` attributes are
+    converted to lowercase.
+
+    Args:
+        attrs: raw attributes
+
+    Returns:
+        cleaned-up attributes
     """
     result = {}
     for attr, value in attrs:
@@ -122,10 +159,19 @@ def fix_attributes(attrs: list[tuple[str, str | None]]) -> dict[str, str]:
 
 def fetch_meta(
     url: str,
-    extractor=Extractor,
+    extractor: type[Extractor] = Extractor,
 ) -> tuple[t.Collection[dict[str, str]], t.Collection[tuple[str, str]]]:
-    """
-    Extract the <link> tags from the HTML document at the given URL.
+    """Extract the <link> tags from the HTML document at the given URL.
+
+    As this is fetching the document over HTTP, it can also support the
+    [Link header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Link).
+
+    Args:
+        url: URL of the document to extract the link tags from.
+        extractor: an Extractor subclass
+
+    Returns:
+        The link tag data and any properties discovered in meta tags.
     """
     links = []
     properties = []

--- a/src/komorebi/adjunct/ogp.py
+++ b/src/komorebi/adjunct/ogp.py
@@ -1,7 +1,7 @@
 """
 An intensely pragmatic implementation of the Open Graph Protocol.
 
-This follows `the specification <https://opengraphprotocol.org/>`_ rather than
+This follows [the specification](https://opengraphprotocol.org/) rather than
 attempting to implement RDFa.
 
 # Theory of Operation
@@ -14,10 +14,13 @@ attached to a property (thus making it structured) has the form "ns:name:meta".
 Metadata should be implemented as a multimap, but I'll be treating it as a map.
 
 Example of prefix with multiple entries:
-<body prefix="dc: http://purl.org/dc/terms/ schema: http://schema.org/">
 
-If this is present: vocab="http://www.w3.org/2011/rdfa-context/rdfa-1.1"
-An initial context is set up consisting of the namespaces given on that page.
+```xml
+<body prefix="dc: http://purl.org/dc/terms/ schema: http://schema.org/">
+```
+
+If this is present: `vocab="http://www.w3.org/2011/rdfa-context/rdfa-1.1"`,
+an initial context is set up consisting of the namespaces given on that page.
 """
 
 import dataclasses
@@ -43,6 +46,7 @@ class Property:
 
 
 def parse(properties: t.Collection[tuple[str, str]]) -> t.Sequence[Property]:
+    """"""
     result = []
     for name, value in properties:
         name_parts = name.split(":", 2)
@@ -57,6 +61,7 @@ def parse(properties: t.Collection[tuple[str, str]]) -> t.Sequence[Property]:
 
 
 def to_meta(props: Property | t.Sequence[Property]) -> str:
+    """"""
     if isinstance(props, Property):
         return props.to_meta()
     return "\n".join(prop.to_meta() for prop in props)
@@ -67,6 +72,7 @@ def find(
     type_: str,
     value: str | None = None,
 ) -> t.Iterable[Property]:
+    """"""
     for prop in props:
         if prop.type_ == type_ and (value is None or prop.value == value):
             yield prop

--- a/src/komorebi/adjunct/time.py
+++ b/src/komorebi/adjunct/time.py
@@ -1,19 +1,37 @@
+"""Date/time utilities."""
+
 import datetime
 
 
 def parse_dt(
     dt: str,
-    tz: datetime.timezone = datetime.UTC,
+    tz: datetime.timezone | None = datetime.UTC,
 ) -> datetime.datetime:
     """Parse an SQLite datetime, treating it as UTC.
 
-    If you want it treated naively, pass `None` as the timezone.
+    Args:
+        dt: an SQLite timestamp string
+        tz: the timezone to use, or `None` to treat it naively
+
+    Returns:
+        the parsed datetime
     """
     parsed = datetime.datetime.strptime(dt, "%Y-%m-%d %H:%M:%S")  # noqa: DTZ007
     return parsed if tz is None else parsed.replace(tzinfo=tz)
 
 
 def to_iso_date(dt: str) -> str:
+    """Convert an SQLite timestamp string to [ISO 8601] format.
+
+    [ISO 8601]: http://en.wikipedia.org/wiki/ISO_8601
+
+    Args:
+        dt: an SQLite timestamp string
+
+    Returns:
+        the same timestamp, but in ISO 8601 format.
+
+    """
     return parse_dt(dt).isoformat()
 
 

--- a/src/komorebi/adjunct/xmlutils.py
+++ b/src/komorebi/adjunct/xmlutils.py
@@ -1,6 +1,4 @@
-"""
-XML utilities.
-"""
+"""XML utilities."""
 
 import contextlib
 import io
@@ -8,30 +6,33 @@ from xml.sax import saxutils
 
 
 class XMLBuilder:
+    """An XML document builder.
+
+    It's purposely namespace ignorant: it's up to user to supply appropriate
+    `xmlns` attributes as needed.
+
+    Examples:
+        >>> xml = XMLBuilder()
+        >>> with xml.within('root', xmlns='tag:talideon.com,2013:test'):
+        ...     xml += 'Before'
+        ...     with xml.within('leaf'):
+        ...         xml += 'Within'
+        ...     xml += 'After'
+        ...     xml.tag('leaf', 'Another')
+        >>> print xml.as_string()
+        <?xml version="1.0" encoding="utf-8"?>
+        <root xmlns="tag:talideon.com,2013:test">Before<leaf>Within</leaf>After<leaf>Another</leaf></root>
+
+    Args:
+        out: a file-like object to write the document to; if none is provided,
+            a buffer is created.
+
+    Note:
+        If you provide your own, the `as_string()` method will return an empty
+        string as no other sensible value can be returned.
     """
-    XML document builder. The code is purposely namespace ignorant: it's up to
-    user to supply appropriate `xmlns` attributes as needed.
 
-    >>> xml = XMLBuilder()
-    >>> with xml.within('root', xmlns='tag:talideon.com,2013:test'):
-    ...     xml += 'Before'
-    ...     with xml.within('leaf'):
-    ...         xml += 'Within'
-    ...     xml += 'After'
-    ...     xml.tag('leaf', 'Another')
-    >>> print xml.as_string()
-    <?xml version="1.0" encoding="utf-8"?>
-    <root xmlns="tag:talideon.com,2013:test">Before<leaf>Within</leaf>After<leaf>Another</leaf></root>
-    """
-
-    def __init__(self, out=None, encoding: str = "utf-8") -> None:
-        """
-        `out` should be a file-like object to write the document to. If none
-        is provided, a buffer is created.
-
-        Note that if you provide your own, `as_string()` will return `None`
-        as no other sensible value can be returned.
-        """
+    def __init__(self, out: io.IOBase | None = None, encoding: str = "utf-8") -> None:
         self.buffer = None
         if out is None:
             self.buffer = io.StringIO()
@@ -40,17 +41,24 @@ class XMLBuilder:
         self.generator.startDocument()
 
     @contextlib.contextmanager
-    def within(self, tag: str, **attrs):
-        """
-        Generates an element containing nested elements.
+    def within(self, tag: str, **attrs: str):
+        """Generates an element containing nested elements.
+
+        Args:
+            tag: the tag name
+            attrs: any attributes to add to the tag
         """
         self.generator.startElement(tag, attrs)  # type: ignore
         yield
         self.generator.endElement(tag)
 
-    def tag(self, tag: str, *values, **attrs) -> None:
-        """
-        Generates a simple element.
+    def tag(self, tag: str, *values: str, **attrs: str) -> None:
+        """Generates a simple element.
+
+        Args:
+            tag: the tag name
+            values: any character data to write between the start and end tag
+            attrs: any attributes to add to the tag
         """
         self.generator.startElement(tag, attrs)  # type: ignore
         for value in values:
@@ -60,23 +68,21 @@ class XMLBuilder:
     def __getattr__(self, tag: str):
         return lambda *values, **attrs: self.tag(tag, *values, **attrs)
 
-    def append(self, other: str):
-        """
-        Append the string to this document.
+    def append(self, other: str) -> "XMLBuilder":
+        """Append the string to this document.
+
+        Args:
+            other: a string to write to the document
         """
         self.generator.characters(other)
         return self
 
     def as_string(self) -> str:
-        """
-        If using the built-in buffer, get its current contents.
-        """
+        """If using the built-in buffer, get its current contents."""
         return "" if self.buffer is None else self.buffer.getvalue()
 
     def close(self) -> None:
-        """
-        If using the built-in buffer, clean it up.
-        """
+        """If using the built-in buffer, clean it up."""
         if self.buffer is not None:
             self.buffer.close()
             self.buffer = None

--- a/src/komorebi/blog.py
+++ b/src/komorebi/blog.py
@@ -46,7 +46,7 @@ def archive() -> str:
     return render_template("archive.html", entries=process_archive(db.query_archive()))
 
 
-def process_archive(records: t.List[dict]) -> t.Iterator[dict]:
+def process_archive(records: t.Iterable[dict]) -> t.Iterator[dict]:
     year = None
     last_month = 0
     for record in records:


### PR DESCRIPTION
This brings what's in Adjunct 0.4.1 into Komorebi. This is mostly more documentation and type annotations, but there are some minor interface change too, mostly a narrowing of what's considered public.

## Summary by Sourcery

Align adjunct helper modules with the latest upstream version, tightening the public API and improving type hints and documentation throughout.

New Features:
- Expose an oEmbed fetch() helper alongside get_oembed for retrieving oEmbed documents directly.

Enhancements:
- Clarify and expand docstrings for HTML discovery, oEmbed, XML building, password file handling, HTML utilities, time parsing, HTTP header parsing, and Open Graph helpers.
- Narrow and formalise public APIs by making various internal helpers private, adding explicit type annotations, and adjusting function signatures to be more precise or flexible where appropriate (for example in archive processing).

Build:
- Tidy the Ruff lint configuration comment for TRY003 in pyproject.toml.