### PR TITLE
Sync with adjunct; fix up some incorrect types

### DIFF
--- a/src/komorebi/adjunct/html.py
+++ b/src/komorebi/adjunct/html.py
@@ -90,7 +90,7 @@ class Element:
     def __iter__(self):
         return iter(self.children)
 
-    def serialize(self, dest: io.TextIOBase | None = None) -> io.TextIOBase:
+    def serialize(self, dest: t.TextIO | None = None) -> t.TextIO:
         """Serialise the element to a file-like object.
 
         Args:

--- a/src/komorebi/adjunct/time.py
+++ b/src/komorebi/adjunct/time.py
@@ -5,7 +5,7 @@ import datetime
 
 def parse_dt(
     dt: str,
-    tz: datetime.timezone | None = datetime.UTC,
+    tz: datetime.tzinfo | None = datetime.UTC,
 ) -> datetime.datetime:
     """Parse an SQLite datetime, treating it as UTC by default.
 
@@ -20,7 +20,7 @@ def parse_dt(
     return parsed if tz is None else parsed.replace(tzinfo=tz)
 
 
-def to_iso_date(dt: str, tz: datetime.timezone = datetime.UTC) -> str:
+def to_iso_date(dt: str, tz: datetime.tzinfo = datetime.UTC) -> str:
     """Convert an SQLite timestamp string to [ISO 8601] format.
 
     [ISO 8601]: http://en.wikipedia.org/wiki/ISO_8601

--- a/src/komorebi/adjunct/time.py
+++ b/src/komorebi/adjunct/time.py
@@ -7,32 +7,32 @@ def parse_dt(
     dt: str,
     tz: datetime.timezone | None = datetime.UTC,
 ) -> datetime.datetime:
-    """Parse an SQLite datetime, treating it as UTC.
+    """Parse an SQLite datetime, treating it as UTC by default.
 
     Args:
         dt: an SQLite timestamp string
         tz: the timezone to use, or `None` to treat it naively
 
     Returns:
-        the parsed datetime
+        the parsed datetime.
     """
     parsed = datetime.datetime.strptime(dt, "%Y-%m-%d %H:%M:%S")  # noqa: DTZ007
     return parsed if tz is None else parsed.replace(tzinfo=tz)
 
 
-def to_iso_date(dt: str) -> str:
+def to_iso_date(dt: str, tz: datetime.timezone = datetime.UTC) -> str:
     """Convert an SQLite timestamp string to [ISO 8601] format.
 
     [ISO 8601]: http://en.wikipedia.org/wiki/ISO_8601
 
     Args:
         dt: an SQLite timestamp string
+        tz: a timezone object
 
     Returns:
         the same timestamp, but in ISO 8601 format.
-
     """
-    return parse_dt(dt).isoformat()
+    return parse_dt(dt, tz).isoformat()
 
 
 def to_wayback_date(dt: str) -> str:

--- a/src/komorebi/adjunct/xmlutils.py
+++ b/src/komorebi/adjunct/xmlutils.py
@@ -2,6 +2,7 @@
 
 import contextlib
 import io
+import typing as t
 from xml.sax import saxutils
 
 
@@ -32,7 +33,7 @@ class XMLBuilder:
         string as no other sensible value can be returned.
     """
 
-    def __init__(self, out: io.IOBase | None = None, encoding: str = "utf-8") -> None:
+    def __init__(self, out: t.TextIO | None = None, encoding: str = "utf-8") -> None:
         self.buffer = None
         if out is None:
             self.buffer = io.StringIO()

--- a/src/komorebi/blog.py
+++ b/src/komorebi/blog.py
@@ -29,11 +29,11 @@ auth = HTTPBasicAuth()
 
 
 @auth.verify_password
-def verify_password(username: str, password: str):
+def verify_password(username: str, password: str) -> bool:
     passwd_path = current_app.config.get("PASSWD_PATH")
-    if passwd_path is not None:
-        return passkit.JSONPasswdFile(passwd_path).check_password(username, password)
-    return False
+    if passwd_path is None:
+        return False
+    return passkit.JSONPasswdFile(passwd_path).check_password(username, password)
 
 
 @blog.route("/")
@@ -145,7 +145,7 @@ def add_entry() -> Response | str:
 
 @blog.route("/<int:entry_id>/edit", methods=["GET", "POST"])
 @auth.login_required
-def edit_entry(entry_id: int) -> str:
+def edit_entry(entry_id: int) -> Response | str:
     entry = db.query_entry(entry_id)
     if entry is None:
         abort(404)


### PR DESCRIPTION
## Summary by Sourcery

Align time, HTML, XML, and authentication utilities with the adjunct library and correct type hints and return types.

New Features:
- Allow ISO date conversion from SQLite timestamps to use a configurable timezone instead of always assuming UTC.

Bug Fixes:
- Ensure blog authentication helpers always return a boolean and handle missing password files safely.
- Correct the declared return type of the blog entry edit route to reflect possible HTTP responses.

Enhancements:
- Update datetime parsing and conversion helpers to default to explicit UTC handling while supporting timezone injection.
- Tighten type hints for HTML serialization and XML building to use text-oriented file-like interfaces.