### PR TITLE
Avoid reinstantiating the markdown parser for each entry

### DIFF
--- a/src/komorebi/formatting.py
+++ b/src/komorebi/formatting.py
@@ -23,4 +23,4 @@ def render_markdown(text: str | None) -> str:
             ],
         )
         _formatter.set(formatter)
-    return formatter.convert(text)
+    return formatter.reset().convert(text)

--- a/src/komorebi/formatting.py
+++ b/src/komorebi/formatting.py
@@ -1,19 +1,26 @@
+import contextvars
 
-import markdown as md
+import markdown
+
+_formatter = contextvars.ContextVar("_formatter")
 
 
 def render_markdown(text: str | None) -> str:
     if text is None:
         return ""
-    return md.markdown(
-        text,
-        output_format="html",
-        extensions=[
-            "smarty",
-            "tables",
-            "attr_list",
-            "def_list",
-            "fenced_code",
-            "admonition",
-        ],
-    )
+    try:
+        formatter = _formatter.get()
+    except LookupError:
+        formatter = markdown.Markdown(
+            output_format="html",
+            extensions=[
+                "smarty",
+                "tables",
+                "attr_list",
+                "def_list",
+                "fenced_code",
+                "admonition",
+            ],
+        )
+        _formatter.set(formatter)
+    return formatter.convert(text)


### PR DESCRIPTION
No idea if this will speed anything up, but it'll get rid of a lot of logging noise in debug mode.

## Summary by Sourcery

Enhancements:
- Introduce a context-local cached Markdown formatter to avoid repeated instantiation and reduce overhead in render_markdown.