### PR TITLE
fixups: expose __version__ and fix a coverage pragma

### DIFF
--- a/src/komorebi/__init__.py
+++ b/src/komorebi/__init__.py
@@ -1,6 +1,13 @@
 from .app import create_app, create_wsgi_app
 
+try:
+    from ._version import __version__
+except ImportError:
+    __version__ = "0.0.0-dev"
+
+
 __all__ = [
+    "__version__",
     "create_app",
     "create_wsgi_app",
 ]

--- a/src/komorebi/adjunct/passkit.py
+++ b/src/komorebi/adjunct/passkit.py
@@ -215,7 +215,7 @@ class JSONPasswdFile:
         return False
 
 
-def make_parser() -> argparse.ArgumentParser:  # pragma; no cover
+def make_parser() -> argparse.ArgumentParser:  # pragma: no cover
     parser = argparse.ArgumentParser(description="jsonpasswd editor")
     group = parser.add_mutually_exclusive_group(required=True)
     group.add_argument("--list", action="store_true", help="List users")


### PR DESCRIPTION
## Summary by Sourcery

Expose the package version at the top level and correct a test coverage pragma.

New Features:
- Expose the package __version__ attribute via the top-level komorebi package, with a default development version when unavailable.

Bug Fixes:
- Fix an incorrect coverage pragma comment on the passkit argument parser helper function so it is properly excluded from coverage.