### PR TITLE
Very basic caching support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -115,9 +115,6 @@ manifest of this stuff to avoid manual updates.
 TODO
 ====
 
-* Get `Flask-Caching`__ into the FreeBSD ports tree so I can use it. This is
-  needed because the mechanism used to generate the archive page is a bit
-  crazy.
 * Some kind of simple admin backend to allow editing and posting of new
   entries. Or if I were feeling particularly inspired, I could implement
   Micropub__...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
   "markdown>=3.8.2,<4",
   "itsdangerous>=2.2.0,<3",
   "firebirdsql==1.3.5",
+  "flask-caching==2.2.0",
 ]
 
 [project.urls]

--- a/src/komorebi/app.py
+++ b/src/komorebi/app.py
@@ -14,6 +14,7 @@ def create_app(*, testing: bool = False) -> Flask:
                 "SERVER_NAME": "example.com",
                 "APPLICATION_ROOT": "/site/",
                 "PREFERRED_URI_SCHEME": "http",
+                "CACHE_TYPE": "NullBackend",
             }
         )
     app.register_blueprint(blog.blog)

--- a/src/komorebi/app.py
+++ b/src/komorebi/app.py
@@ -1,6 +1,6 @@
 from flask import Flask, render_template
 
-from . import blog, db, sri
+from . import blog, caching, db, sri
 
 
 def create_app(*, testing: bool = False) -> Flask:
@@ -19,6 +19,7 @@ def create_app(*, testing: bool = False) -> Flask:
     app.register_blueprint(blog.blog)
     app.cli.add_command(sri.generate_hashes)
     db.init_app(app)
+    caching.cache.init_app(app)
 
     @app.errorhandler(404)
     def page_not_found(_):

--- a/src/komorebi/app.py
+++ b/src/komorebi/app.py
@@ -14,7 +14,7 @@ def create_app(*, testing: bool = False) -> Flask:
                 "SERVER_NAME": "example.com",
                 "APPLICATION_ROOT": "/site/",
                 "PREFERRED_URI_SCHEME": "http",
-                "CACHE_TYPE": "NullBackend",
+                "CACHE_TYPE": "NullCache",
             }
         )
     app.register_blueprint(blog.blog)

--- a/src/komorebi/blog.py
+++ b/src/komorebi/blog.py
@@ -17,6 +17,7 @@ from flask_httpauth import HTTPBasicAuth
 
 from . import db, embeds, formatting, forms
 from .adjunct import passkit
+from .caching import cache
 from .feed import generate_feed
 
 blog = Blueprint("blog", __name__)
@@ -39,6 +40,7 @@ def latest() -> str:
 
 
 @blog.route("/archive")
+@cache.cached(timeout=60 * 60)
 def archive() -> str:
     return render_template("archive.html", entries=process_archive(db.query_archive()))
 
@@ -73,6 +75,7 @@ def process_archive(records: t.Iterable[db.ArchiveMonth]) -> t.Iterable[db.Archi
 
 
 @blog.route("/feed")
+@cache.cached(timeout=5 * 60)
 def feed() -> Response:
     response = Response(content_type="application/atom+xml; charset=UTF-8")
     response.cache_control.public = True
@@ -99,6 +102,7 @@ def feed() -> Response:
 
 
 @blog.route("/<string(length=4):year>-<string(length=2):month>", endpoint="month")
+@cache.cached(timeout=60 * 60)
 def render_month(year: str, month: str) -> str:
     entries = db.query_month(int(year), int(month))
     if not entries:

--- a/src/komorebi/caching.py
+++ b/src/komorebi/caching.py
@@ -1,0 +1,7 @@
+from flask_caching import Cache
+
+__all__ = [
+    "cache",
+]
+
+cache = Cache()

--- a/src/komorebi/db.py
+++ b/src/komorebi/db.py
@@ -19,7 +19,7 @@ def get_connection() -> firebirdsql.Connection:
     return g.db
 
 
-def close_db(exc):
+def close_connection(exc):
     conn = g.pop("db", None)
     if conn is not None:
         try:
@@ -32,7 +32,7 @@ def close_db(exc):
 
 
 def init_app(app: Flask) -> None:
-    app.teardown_appcontext(close_db)
+    app.teardown_appcontext(close_connection)
 
 
 def execute(sql: str, args: tuple[Scalar, ...] = ()) -> int | None:

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,15 @@ wheels = [
 ]
 
 [[package]]
+name = "cachelib"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/f2/1c76df4d295789bbc836eea50b813d64f86e640c29fe8f0a3686e9c4e3e9/cachelib-0.9.0.tar.gz", hash = "sha256:38222cc7c1b79a23606de5c2607f4925779e37cdcea1c2ad21b8bae94b5425a5", size = 21007, upload-time = "2022-06-26T17:56:58.916Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/70/58e525451478055b0fd2859b22226888a6985d404fe65e014fc4893d3b75/cachelib-0.9.0-py3-none-any.whl", hash = "sha256:811ceeb1209d2fe51cd2b62810bd1eccf70feba5c52641532498be5c675493b3", size = 15716, upload-time = "2022-06-26T17:56:57.055Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -115,6 +124,19 @@ wheels = [
 ]
 
 [[package]]
+name = "flask-caching"
+version = "2.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cachelib" },
+    { name = "flask" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3b/03/d643dee9286ac4700b786e71e87184b1418e6887405b31c47efd6fe2ce9f/flask_caching-2.2.0.tar.gz", hash = "sha256:9d2d30ee02250c47c3650fd6781b79e92d5964d91382a3697e5ebaf77ca0ea4f", size = 67478, upload-time = "2024-04-27T16:07:27.805Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2b/d2/dabe1aa77855713ef3b2a0095f2f35c0383100b776bce1f6b036ddd1863b/Flask_Caching-2.2.0-py3-none-any.whl", hash = "sha256:5b74ad9e263cc3c5ac9c2d33c094eb99294b111ace78ccaa665d6b852b907e14", size = 28763, upload-time = "2024-04-27T16:07:25.6Z" },
+]
+
+[[package]]
 name = "flask-httpauth"
 version = "4.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -176,6 +198,7 @@ source = { editable = "." }
 dependencies = [
     { name = "firebirdsql" },
     { name = "flask" },
+    { name = "flask-caching" },
     { name = "flask-httpauth" },
     { name = "flask-wtf" },
     { name = "itsdangerous" },
@@ -196,6 +219,7 @@ dev = [
 requires-dist = [
     { name = "firebirdsql", specifier = "==1.3.5" },
     { name = "flask", specifier = ">=3.1.1,<4" },
+    { name = "flask-caching", specifier = "==2.2.0" },
     { name = "flask-httpauth", specifier = ">=4.8.0,<5" },
     { name = "flask-wtf", specifier = "~=1.2.1" },
     { name = "itsdangerous", specifier = ">=2.2.0,<3" },


### PR DESCRIPTION
This means that some of the more expensive views (the archive) and those that aren't time sensitive (the feed and monthly archives) get cached.

I'd like to do the same for entries and the homepage, but that'll require me to figure out a sensible invalidation strategy, similar to what I had with AFK's caching implementation.

Yes, the cache timeouts are hardwired. I expect Sourcery to complain about that...

## Summary by Sourcery

Introduce basic Flask-Caching integration and apply it to selected blog views to reduce load on expensive or non‑time‑sensitive pages.

New Features:
- Add a shared Flask-Caching cache instance and initialize it with the Flask application.
- Enable caching for the archive, feed, and monthly archive blog routes with fixed timeouts.

Enhancements:
- Rename the database teardown callback to better reflect its purpose.
- Configure a default null cache backend for the test environment.

Build:
- Add flask-caching as an application dependency.