### PR TITLE
Remove unused oembed.oembed field

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ dist/
 htmlcov/
 results.xml
 .*_cache/
+dev/cache/
 
 # General detritus
 *~

--- a/schema/schema.firebird.sql
+++ b/schema/schema.firebird.sql
@@ -13,6 +13,5 @@ CREATE INDEX ix_links_modified ON links (time_m);
 
 CREATE TABLE oembed (
     id     INTEGER                 NOT NULL PRIMARY KEY,
-    oembed BLOB CHARACTER SET UTF8 NOT NULL,
     html   BLOB CHARACTER SET UTF8 NOT NULL
 );

--- a/schema/schema.sqlite.sql
+++ b/schema/schema.sqlite.sql
@@ -17,8 +17,6 @@ CREATE INDEX links_modified ON links (time_m);
 CREATE TABLE oembed (
 	-- Same ID as the matching link
 	id     INTEGER NOT NULL PRIMARY KEY,
-	-- The original oEmbed data
-	oembed TEXT    NOT NULL,
 	-- We transform the image into HTML
 	html   TEXT    NOT NULL
 );


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Simplify oembed table definitions by dropping the unused oembed field from SQLite and Firebird schemas.