### PR TITLE
Fix various nits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,11 +27,11 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 FROM gcr.io/distroless/cc:nonroot
 
 # Copy the Python version
-COPY --from=builder --chown=python:python /python /python
+COPY --from=builder /python /python
 
 WORKDIR /app
 # Copy the application from the builder
-COPY --from=builder --chown=app:app /app/.venv /app/.venv
+COPY --from=builder /app/.venv /app/.venv
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"

--- a/justfile
+++ b/justfile
@@ -1,5 +1,5 @@
 app := "komorebi"
-docker_repo := "ghcr.io/kgaughan/" + app
+container_repo := "ghcr.io/kgaughan/" + app
 
 [private]
 default:
@@ -34,9 +34,9 @@ clean:
 	@rm -rf .mypy_cache .pytest_cache .ruff_cache .venv dist htmlcov .coverage
 	@find . -name \*.orig -delete
 
-# build the docker image
-docker:
+# build the container image
+container:
 	@rm -rf dist
 	@uv build --wheel
-	@docker buildx build -t {{docker_repo}}:$(git describe --tags --always) .
-	@docker tag {{docker_repo}}:$(git describe --tags --always) {{docker_repo}}:latest
+	@podman build -t {{container_repo}}:$(git describe --tags --always) .
+	@podman tag {{container_repo}}:$(git describe --tags --always) {{container_repo}}:latest

--- a/src/komorebi/static/common.js
+++ b/src/komorebi/static/common.js
@@ -1,9 +1,8 @@
 // Humanise any timestamps
 window.addEventListener("DOMContentLoaded", () => {
-	let humanise = (dt) => dayjs(dt).fromNow();
 	document.querySelectorAll("time").forEach((elem, _) => {
 		if (elem.dateTime != "") {
-			elem.innerText = humanise(elem.dateTime);
+			elem.innerText = dayjs(elem.dateTime).fromNow();
 		}
 	});
 });


### PR DESCRIPTION
* Switch to podman
 * Inline the humanise function

I had to remove the the `--chown` flags as I believe they're a leftover from an earlier attempt to dockerise things.

## Summary by Sourcery

Switch container build tooling and clean up minor implementation details.

Build:
- Rename the image build target from `docker` to `container` and switch the build commands from Docker to Podman in the justfile.
- Rename the Docker image repository variable to a more generic container repository name in the justfile.
- Remove use of `--chown` from Dockerfile COPY instructions to simplify the image build.