### PR TITLE
Pass uv.lock in the build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,3 +2,4 @@
 # The bare minimum needed to build the image
 !dist/*.whl
 !pyproject.toml
+!uv.lock


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Touch .dockerignore as part of adjusting Docker build context for future changes.