### PR TITLE
The SRI for common.js wasn't updated in #72 as it ought

### DIFF
--- a/src/komorebi/sri.json
+++ b/src/komorebi/sri.json
@@ -1,5 +1,5 @@
 {
-  "common.js": "sha384-NwLKHa6Oq+O9zgMUKeSXqbeWLQSGg6zVQnaGSo8jE/RkzN7xjMfXJ20JXrl5NTHj",
+  "common.js": "sha384-5Ol8dya+yWf/QuN/dpH5BB7tJhymZx074LV9WOcJpQuWV+pRXGHsWtI0kC9jHO9H",
   "dayjs.min.js": "sha384-qKOGKwlxNqVZhquaywex6q1R6Le1uR5tc1BYZqDKKctqN7VkuYyVUhK2dSdDIXXz",
   "htmx.min.js": "sha384-/TgkGk7p307TH7EXJDuUlgG3Ce1UVolAOFopFekQkkXihi5u/6OCvVKyz1W+idaz",
   "screen.css": "sha384-t/LYFX2OsraZoLKSgsSTmlqzBARUrTAT+IHNH8UxDpy58u3dRFDmOK1ehfiAZce+"


### PR DESCRIPTION
## Summary by Sourcery

Enhancements:
- Refresh the Subresource Integrity entry for the common.js bundle in the Komorebi SRI manifest.