### PR TITLE
Fix the update form

### DIFF
--- a/src/komorebi/adjunct/ogp.py
+++ b/src/komorebi/adjunct/ogp.py
@@ -1,5 +1,4 @@
-"""
-An intensely pragmatic implementation of the Open Graph Protocol.
+"""An intensely pragmatic implementation of the Open Graph Protocol.
 
 This follows [the specification](https://opengraphprotocol.org/) rather than
 attempting to implement RDFa.
@@ -30,6 +29,14 @@ import typing as t
 
 @dataclasses.dataclass
 class Property:
+    """Open Graph Property.
+
+    Attributes:
+        type_: The property type (e.g., "title", "image", etc.).
+        value: The property value.
+        metadata: A mapping of metadata keys to values.
+    """
+
     type_: str
     value: str
     metadata: dict[str, str]
@@ -44,9 +51,20 @@ class Property:
         )
         return "\n".join(lines)
 
+    def __str__(self) -> str:
+        return self.to_meta()
 
-def parse(properties: t.Collection[tuple[str, str]]) -> t.Sequence[Property]:
-    """"""
+
+def parse(properties: t.Collection[tuple[str, str]]) -> list[Property]:
+    """Parse Open Graph properties from a list of name-value pairs.
+
+    Args:
+        properties: A collection of (name, value) pairs representing Open Graph
+            properties.
+
+    Returns:
+        The `Property` instances.
+    """
     result = []
     for name, value in properties:
         name_parts = name.split(":", 2)
@@ -61,7 +79,14 @@ def parse(properties: t.Collection[tuple[str, str]]) -> t.Sequence[Property]:
 
 
 def to_meta(props: Property | t.Sequence[Property]) -> str:
-    """"""
+    """Convert Open Graph properties to HTML meta tags.
+
+    Args:
+        props: A single `Property` instance or a sequence of `Property` instances.
+
+    Returns:
+        A string containing HTML meta tags representing the Open Graph properties.
+    """
     if isinstance(props, Property):
         return props.to_meta()
     return "\n".join(prop.to_meta() for prop in props)
@@ -72,7 +97,16 @@ def find(
     type_: str,
     value: str | None = None,
 ) -> t.Iterable[Property]:
-    """"""
+    """Find Open Graph properties by type and optional value.
+
+    Args:
+        props: A sequence of `Property` instances to search.
+        type_: The property type to search for.
+        value: An optional property value to match.
+
+    Returns:
+        An iterable of `Property` instances that match the specified type and value.
+    """
     for prop in props:
         if prop.type_ == type_ and (value is None or prop.value == value):
             yield prop

--- a/src/komorebi/db.py
+++ b/src/komorebi/db.py
@@ -63,7 +63,8 @@ def query_row(sql: str, args: tuple[Scalar, ...] = ()) -> dict[str, Scalar] | No
     try:
         cur.execute(sql, args)
         if row := cur.fetchonemap():
-            return row
+            # Hack to get the update form working properly.
+            return {k.lower(): v for k, v in row.items()}
     finally:
         cur.close()
     return None


### PR DESCRIPTION
The field names need to be normalised to lowercase to work with wtforms. FirebirdSQL normalises everything to uppercase, unfortunately.

There are a few other bits bundled in, like extra comments copied across from Adjunct, caching of the homepage, and compression of responses before the cache.

## Summary by Sourcery

Normalize database row keys to lowercase for WTForms compatibility and improve blog performance and OGP utilities.

New Features:
- Add homepage caching for the latest blog entries and invalidate it when entries are created or edited.
- Add string conversion and richer parsing helpers for Open Graph Protocol properties.

Bug Fixes:
- Normalize query_row result keys to lowercase to fix the update form when using FirebirdSQL's uppercase column names.

Enhancements:
- Document the Open Graph Property dataclass and related helper functions.
- Ensure compression runs before caching for blog responses to store compressed content in the cache.