### PR TITLE
Render the version string; bump year in copyright

### DIFF
--- a/src/komorebi/app.py
+++ b/src/komorebi/app.py
@@ -1,6 +1,6 @@
 from flask import Flask, render_template
 
-from . import blog, db, extensions, sri
+from . import _version, blog, db, extensions, sri
 
 
 def create_app(*, testing: bool = False) -> Flask:
@@ -32,6 +32,10 @@ def create_app(*, testing: bool = False) -> Flask:
     db.init_app(app)
     extensions.cache.init_app(app)
     extensions.compress.init_app(app)
+
+    @app.template_global()
+    def app_version():
+        return _version.__version__
 
     @app.errorhandler(404)
     def page_not_found(_):

--- a/src/komorebi/static/screen.css
+++ b/src/komorebi/static/screen.css
@@ -98,8 +98,9 @@ html{line-height:1.15;-webkit-text-size-adjust:100%}body{margin:0}main{display:b
 body {
   font-family: 'Raleway', sans-serif;
   font-display: swap;
-  display: block;
-  position: relative;
+  display: grid;
+  grid-template-rows: auto 1fr auto;
+  min-height: 100vh;
   width: 100%;
   margin: 0;
   padding: 0;
@@ -120,7 +121,6 @@ body>header {
   background-color: #802;
   color: white;
   padding: 2rem 0 1rem 0;
-  margin: 0 auto;
 }
 
 nav {
@@ -153,6 +153,7 @@ body>footer {
 
 body>footer {
   text-align: center;
+  font-size: 80%;
 }
 
 article {

--- a/src/komorebi/templates/base.html
+++ b/src/komorebi/templates/base.html
@@ -38,7 +38,7 @@
 		</nav>
 	</header>
 	<main>{% block content %}{% endblock %}</main>
-	<footer>Served by <a href="https://githbu.com/kgaughan/komorebi">Komorebi/{{ app_version() }}</a></footer>
+	<footer>Served by <a href="https://github.com/kgaughan/komorebi">Komorebi/{{ app_version() }}</a></footer>
 </body>
 
 </html>

--- a/src/komorebi/templates/base.html
+++ b/src/komorebi/templates/base.html
@@ -10,7 +10,8 @@
 	<link rel="preconnect" href="https://fonts.bunny.net" crossorigin="anonymous" referrerpolicy="no-referrer">
 	<link rel="preconnect" href="https://i.ytimg.com" crossorigin="anonymous" referrerpolicy="no-referrer">
 	<meta name="Author" content="Keith Gaughan">
-	<meta name="Copyright" content="Copyright (c) Keith Gaughan, 2001-2022">
+	<meta name="Copyright" content="Copyright (c) Keith Gaughan, 2001-2025">
+	<meta name="Engine" content="Komorebi/{{ app_version() }}">
 
 	<link rel="stylesheet" crossorigin="anonymous" referrerpolicy="no-referrer" media="screen" href="{{ url_for('static', filename='screen.css') }}" integrity="{{ sri('screen.css') }}">
 
@@ -37,6 +38,7 @@
 		</nav>
 	</header>
 	<main>{% block content %}{% endblock %}</main>
+	<footer>Served by <a href="https://githbu.com/kgaughan/komorebi">Komorebi/{{ app_version() }}</a></footer>
 </body>
 
 </html>


### PR DESCRIPTION
I think the theme probably needs a code refresh to use more modern methods.

## Summary by Sourcery

Render the Komorebi application version in the HTML output and modernize the page layout/footer.

New Features:
- Expose the application version as a global template helper and include it in a new HTML meta tag and footer link.

Enhancements:
- Update the base layout to use a CSS grid-based full-height body layout and adjust footer typography.
- Refresh the copyright metadata year range to 2025.