### PR TITLE
Bump the minimum version of pytest-cov and tidy config

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,7 @@ dev = [
   "python-dotenv>=1.1.0",
   "mypy>=1.10.1",
   "pytest>=9.0.0",
-  "pytest-cov>=2.12.1",
+  "pytest-cov>=5.0.0",
   "types-markdown==3.10.0.20251106", # Keep in sync with the markdown release
 ]
 waitress = ["waitress"]
@@ -143,9 +143,16 @@ ban-relative-imports = "all"
 # Tests can use magic values, assertions, and relative imports
 "tests/**/*" = ["ANN", "PLR2004", "S101", "TID252", "E501"]
 
-[tool.pytest.ini_options]
-minversion = "6.0"
-addopts = "-ra --doctest-modules --cov=komorebi --junitxml=results.xml --cov-report html"
+[tool.pytest]
+minversion = "9.0"
+strict = true
+addopts = [
+  "-ra",
+  "--doctest-modules",
+  "--cov=komorebi",
+  "--junitxml=results.xml",
+  "--cov-report=html",
+]
 junit_logging = "out-err"
 junit_family = "xunit2"
 pythonpath = ["src"]

--- a/uv.lock
+++ b/uv.lock
@@ -397,7 +397,7 @@ requires-dist = [
 dev = [
     { name = "mypy", specifier = ">=1.10.1" },
     { name = "pytest", specifier = ">=9.0.0" },
-    { name = "pytest-cov", specifier = ">=2.12.1" },
+    { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "python-dotenv", specifier = ">=1.1.0" },
     { name = "types-markdown", specifier = "==3.10.0.20251106" },
 ]


### PR DESCRIPTION
This has little effect other than aligning with what's in FreeBSD ports.

## Summary by Sourcery

Raise development dependency and testing configuration requirements for pytest and pytest-cov, and align pytest settings with the modern TOML-based configuration format.

Build:
- Increase the minimum pytest-cov development dependency version to 5.0.0.

Tests:
- Update pytest configuration to use the [tool.pytest] TOML section with minversion 9.0, strict mode, and structured addopts while preserving existing test reporting options.