### PR TITLE
Update minumum versions for Flask and Markdown in line with FreeBSD

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,11 +26,11 @@ classifiers = [
 ]
 # The versions are pegged with FreeBSD
 dependencies = [
-  "flask>=3.1.2,<4",
+  "flask>=3.1.3,<4",
   "flask-httpauth>=4.8.0,<5",
   "flask-wtf~=1.2.1",
   "wtforms>=3.1.2,<4",
-  "markdown>=3.10,<4",
+  "markdown>=3.10.2,<4",
   "itsdangerous>=2.2.0,<3",
   "firebirdsql==1.3.5",
   "flask-caching==2.2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -383,13 +383,13 @@ waitress = [
 [package.metadata]
 requires-dist = [
     { name = "firebirdsql", specifier = "==1.3.5" },
-    { name = "flask", specifier = ">=3.1.2,<4" },
+    { name = "flask", specifier = ">=3.1.3,<4" },
     { name = "flask-caching", specifier = "==2.2.0" },
     { name = "flask-compress", specifier = "==1.14" },
     { name = "flask-httpauth", specifier = ">=4.8.0,<5" },
     { name = "flask-wtf", specifier = "~=1.2.1" },
     { name = "itsdangerous", specifier = ">=2.2.0,<3" },
-    { name = "markdown", specifier = ">=3.10,<4" },
+    { name = "markdown", specifier = ">=3.10.2,<4" },
     { name = "wtforms", specifier = ">=3.1.2,<4" },
 ]
 


### PR DESCRIPTION
## Summary by Sourcery

Build:
- Update pyproject dependency constraints to require flask>=3.1.3 and markdown>=3.10.2.